### PR TITLE
Added tear down for toolbar items

### DIFF
--- a/src/MemoryToolkit.Maui/Utilities.cs
+++ b/src/MemoryToolkit.Maui/Utilities.cs
@@ -79,6 +79,12 @@ public static class Utilities
 
             foreach (IVisualTreeElement childElement in vte.GetVisualChildren())
                 TearDownImpl(childElement, false);
+            
+            if (vte is Page page)
+            {
+                foreach (var toolbarItem in page.ToolbarItems)
+                    TearDownImpl(toolbarItem, false);
+            }
 
             if (vte is VisualElement visualElement)
             {


### PR DESCRIPTION
Added a loop to teardown the `ToolbarItems` collection. With this change I don't experience anymore this issue: https://github.com/dotnet/maui/issues/20703