### PR TITLE
catching ObjectDisposed Exception in TearDown()

### DIFF
--- a/src/MemoryToolkit.Maui/Utilities.cs
+++ b/src/MemoryToolkit.Maui/Utilities.cs
@@ -109,7 +109,17 @@ public static class Utilities
                 {
                     TearDownBehavior.OnTearDown?.Invoke(visualElement);
                     if (visualElement.Handler is IDisposable disposableHandler)
-                        disposableHandler.Dispose();
+                    {
+                        try
+                        {
+                            disposableHandler.Dispose();
+                        }
+                        catch(ObjectDisposedException ex)
+                        {
+
+                        }
+                    }
+                       
                     visualElement.Handler?.DisconnectHandler();
                 }
 
@@ -134,7 +144,16 @@ public static class Utilities
 #endif
 
                     if (element.Handler is IDisposable disposableElementHandler)
-                        disposableElementHandler.Dispose();
+                    {
+                        try
+                        {
+                            disposableElementHandler.Dispose();
+                        }
+                        catch (ObjectDisposedException ex)
+                        {
+
+                        }
+                    }
                     element.Handler.DisconnectHandler();
                 }
             }


### PR DESCRIPTION
There is chance the handler of visual element/ element is already disposed by manually, other nugets or MAUI itself. Hence System.ObjectDisposedException is being thrown randomly.

Since there is no way to know if the handler is already disposed. The only possible solution would be to catch it.